### PR TITLE
Fix Cache control logic for DMA transfer

### DIFF
--- a/siop.c
+++ b/siop.c
@@ -554,7 +554,9 @@ siop_scsidone(struct siop_acb *acb, int stat)
      * http://aminet.net/package/docs/misc/MuManual
      *
      */
-    CachePostDMA(&acb->iob_buf, (LONG *)&acb->iob_len, 0);
+    if (acb->iob_buf != NULL && acb->iob_len != 0) {
+        CachePostDMA(&acb->iob_buf, (LONG *)&acb->iob_len, 0);
+    }
 #endif
 
     /* Put it on the free list. */


### PR DESCRIPTION
The changes in this PR aim to resolve an issue that causes certain MMULibs programs to stop working properly.
In my case I found that MuEVD would hang on my system when using the Open Source A4091 Software.

This is because the calls to CachePreDMA and CachePostDMA are not balanced but need to be.

There is a discussion of the implications in [this EAB thread](http://eab.abime.net/showthread.php?t=112793)
More documentation of these functions is available in the [MuManual](http://aminet.net/package/docs/misc/MuManual)

These changes have not been tested yet and are a WIP 