### PR TITLE
Don't probe for SCSI targets on other cards

### DIFF
--- a/attach.c
+++ b/attach.c
@@ -481,6 +481,9 @@ attach(device_t self, uint scsi_target, struct scsipi_periph **periph_p,
     int rc;
     int failed = 0;
 
+    if (scsi_target >= 100)
+        return (ERROR_OPEN_FAIL);
+
     if (target == chan->chan_id)
         return (ERROR_SELF_UNIT);
 


### PR DESCRIPTION
There is a convention that allows a single device driver to take
care of more than one physical card. This gets difficult with
autoconfig devices with drivers living in ROM however.
