### PR TITLE
Make disk bootable

### DIFF
--- a/disk/createdisk.sh
+++ b/disk/createdisk.sh
@@ -24,6 +24,7 @@ xdftool $DISK write $THIRDPARTY/RDBFlags/RDBFlags Tools/RDBFlags
 xdftool $DISK write A4091.guide
 xdftool $DISK write A4091.guide.info
 xdftool $DISK write Disk.info
+xdftool $DISK boot install
 
 echo "Cleaning up..."
 make -s -C $THIRDPARTY/devtest clean


### PR DESCRIPTION
This makes the created adf bootable to make testing a card w/o startup-sequence, etc. easier.