### PR TITLE
Mounter: checksum must pay attention to SummedLongs

### DIFF
--- a/mounter.c
+++ b/mounter.c
@@ -186,7 +186,13 @@ static void copymem(void *dstp, void *srcp, UWORD size)
 static UWORD checksum(UBYTE *buf, struct MountData *md)
 {
 	ULONG chk = 0;
-	for (UWORD i = 0; i < md->blocksize; i += 4) {
+	ULONG num_longs;
+
+	num_longs = (buf[4] << 24) | (buf[5] << 16) | (buf[6] << 8) | (buf[7]);
+	if (num_longs > 65535)
+		return FALSE;
+
+	for (UWORD i = 0; i < (int)(num_longs * sizeof(LONG)); i += 4) {
 		ULONG v = (buf[i + 0] << 24) | (buf[i + 1] << 16) | (buf[i + 2] << 8) | (buf[i + 3 ] << 0);
 		chk += v;
 	}


### PR DESCRIPTION
The amount of checksummed longs doesn't always equal the device blocksize / 4.
When a disk is prepared by HDInstTool it checksums 256 bytes of RDB, PART, LSEG etc 
This issue causes mounter to incorrectly reject HDInstTool prepared disks

This fix was provided by Olaf Barthel @obarthel

Thanks to Jasonsbeer and MichaelD for reporting this issue