### PR TITLE
Mounter: fix offset calculation in readblock()

### DIFF
--- a/mounter.c
+++ b/mounter.c
@@ -217,7 +217,7 @@ static BOOL readblock(UBYTE *buf, ULONG block, ULONG id, struct MountData *md)
 		max_retries = 15;
 
 	request->iotd_Req.io_Command = CMD_READ;
-	request->iotd_Req.io_Offset = block << 9;
+	request->iotd_Req.io_Offset = block * md->blocksize;
 	request->iotd_Req.io_Data = buf;
 	request->iotd_Req.io_Length = md->blocksize;
 	for (i = 0; i < max_retries; i++) {


### PR DESCRIPTION
Mounter: fix offset calculation in readblock() to use the actual block size

Thanks to Olaf Barthel @obarthel for identifying this