### PR TITLE
a4091 -t6 enhancements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,9 @@ LDFLAGS_TOOLS  = -mcrt=clib2 -lgcc -lc -lamiga $(LDFLAGS_COMMON)
 #CFLAGS  += -g
 #LDFLAGS += -g
 
+#CFLAGS_TOOLS  += -g
+#LDFLAGS_TOOLS += -g
+
 # Add link-time optimization (must also have optimization specified in LDFLAGS)
 # -flto
 


### PR DESCRIPTION
Improvements to the a4091 test utility to randomize src and dst address
for the a4091 -tt6 (DMA copy) operation.
Improved DMA fault report detection (Step Interrupt or Illegal Instruction)
Fixed Illegal Instruction bug in the register write test script (benign)