### PR TITLE
mounter: Fix bug in filesystem.resource parsing

### DIFF
--- a/mounter.c
+++ b/mounter.c
@@ -577,6 +577,8 @@ static struct FileSysEntry *FSHDProcess(struct FileSysHeaderBlock *fshb, ULONG d
 			}
 			fse = (struct FileSysEntry*)fse->fse_Node.ln_Succ;
 		}
+		if (fse && fse->fse_DosType != dostype)
+			fse = NULL;
 		if (fshb && newOnly) {
 			fse = AllocMem(sizeof(struct FileSysEntry) + strlen(creator) + 1, MEMF_PUBLIC | MEMF_CLEAR);
 			if (fse) {


### PR DESCRIPTION
When terminating the loop through all file system entries, we don't
want to terminate on whether our current entry has a successor, but
on whether we actually have a node in hand. Otherwise we stop matching
the last filesystem entry against the filesystem we are looking at.
But what is worse, is that we also just blindly returned the last
filesystem entry in that case instead of NULL. This leaves AmigaOS with
a wrongful match, which in certain cases, will crash the system when
trying to mount the filesystem later on.
