### PR TITLE
printf: Drop libdebug and libgcc dependencies

### DIFF
--- a/printf.c
+++ b/printf.c
@@ -245,7 +245,7 @@ kprintn(buf_t *desc, UINTMAX_T value, uint base, int flags, int width, int dot)
 
     do {
         uint32_t rem;
-	value = udiv64_32(&rem, value, base);
+        value = udiv64_32(&rem, value, base);
         uint digit = (uint)rem;
         *p++ = (char) (digit + ((digit <= 9) ? '0' : hex_a));
     } while (value != 0);


### PR DESCRIPTION
Replace library calls with direct assembly implementations to eliminate
external dependencies on libdebug.a and libgcc.a.

Changes:
- Implement custom udiv64_32() using shift-and-subtract algorithm for
  64-bit division, replacing libgcc's __udivdi3. Avoids divul.l
  instruction which is unimplemented on 68060 and would trap before
  68060.library loads.
- Add KPutChar() wrapper that directly calls exec.library RawPutChar
  (offset -516) via inline assembly
- Add KPutS() for string output using the custom KPutChar
- Replace putchar() calls with KPutChar() in put() function
- Modify kprintn() to use udiv64_32() instead of native 64-bit
  modulo and division operators

The inline assembly approach avoids function call overhead and
library linking requirements. Code size reduction: 0xb1cc -> 0xa428
(45,516 -> 41,960 bytes, saving 3,556 bytes).

Tested with bebbo's gcc 13.3 for m68k-amigaos.
