### PR TITLE
sd: Add bounce buffer for Zorro II DMA transfers

### DIFF
--- a/scsipi_base.c
+++ b/scsipi_base.c
@@ -720,9 +720,6 @@ scsipi_get_xs(struct scsipi_periph *periph, int flags)
  *
  *	NOTE: Must be called with channel lock held
  */
-#ifdef PORT_AMIGA
-static
-#endif
 void
 scsipi_put_xs(struct scsipi_xfer *xs)
 {

--- a/scsipi_base.h
+++ b/scsipi_base.h
@@ -13,4 +13,6 @@ int scsipi_command(struct scsipi_periph *periph, struct scsipi_generic *cmd,
     int cmdlen, u_char *data_addr, int datalen, int retries, int timeout,
     struct buf *bp, int flags);
 
+void scsipi_put_xs(struct scsipi_xfer *xs);
+
 #endif /* _SCSIPI_BASE */


### PR DESCRIPTION
A Zorro III device like the A4091 cannot perform DMA transfers directly
to or from the 24-bit address space of Zorro II RAM. On a system with
only Chip RAM and Zorro II Fast RAM, the driver could be asked to
transfer to a buffer in this incompatible memory space, causing the
DMA operation to fail.

Implement a 'bounce buffer' mechanism in the higher-level SCSI disk
driver (sd.c) to work around this hardware limitation.

Before a read/write operation, the buffer address is checked. If it
resides in the Zorro II memory range (0x200000-0xA00000), a temporary
bounce buffer is allocated from DMA-capable Chip RAM.

- For WRITEs, data is copied from the original Z2 buffer to the bounce
  buffer before DMA.
- For READs, data is copied from the bounce buffer back to the original
  Z2 buffer after DMA completion.

The original buffer address is tracked in xs->xs_callback_arg.

To handle synchronous allocation failures for the bounce buffer, the
scsipi_put_xs() function was made public, allowing sd_readwrite() to
correctly release the scsipi_xfer and report an error without causing
a memory leak.
