### PR TITLE
ncr7xx: fix out-of-bounds src buffer in test_dma

### DIFF
--- a/ncr7xx.c
+++ b/ncr7xx.c
@@ -4688,8 +4688,8 @@ test_dma(uint extended)
     int      rc2 = 0;
     uint32_t pos;
     uint     dma_len = 2048;
-    APTR    *tsrc;
-    APTR    *src;
+    uint8_t *tsrc;
+    uint8_t *src;
     ULONG    buf_handled;
     uint32_t diff;
     uint32_t addr;
@@ -4918,9 +4918,9 @@ test_dma_copy(uint extended)
     uint      bf_buffers    = 0;
     uint      bf_notram     = 0;
     VAPTR    *src_backup;
-    APTR     *src;
-    APTR     *dst;
-    APTR     *dst_buf;
+    uint8_t  *src;
+    uint8_t  *dst;
+    uint8_t  *dst_buf;
     uint32_t *bf_addr;
     uint32_t *bf_mem;
     uint8_t   bf_flags[32][32];
@@ -4965,7 +4965,7 @@ test_dma_copy(uint extended)
     }
 
     /* Land DMA in the middle of the buffer */
-    dst = (APTR) ((uint32_t) dst_buf + dma_len);
+    dst = dst_buf + dma_len;
 
     bf_addr = AllocMem(BFADDR_SIZE, MEMF_PUBLIC | MEMF_CLEAR);
     bf_mem = AllocMem(BFADDR_SIZE, MEMF_PUBLIC | MEMF_CLEAR);


### PR DESCRIPTION
## Problem

In `test_dma`, the DMA scratch buffers are declared `APTR *` (pointer-to-`APTR`). Since `APTR` is `void *`, the setup line

```c
src = tsrc + dma_len;
```

is C pointer arithmetic on a `void **`, so it strides `dma_len * sizeof(void*)` = `2048 * 4` = **8192 bytes** into a **6144-byte** allocation. `src` (and every DMA test 1/2/3 write through it) ends up **2-4 KB past the end of the buffer**. The intent was a byte offset of `dma_len` -- `src` sits in the middle third of the `dma_len * 3` allocation, with the outer thirds acting as guard padding.

Without a memory watcher the overrun silently scribbles adjacent heap and the test still "passes" (the DMA reads back its own garbage). Under MuForce/MuGuardianAngel it surfaces as `LONG WRITE` hits into the poisoned page and `SegList is invalid` corruption, intermittently depending on what Exec placed after the buffer. Confirmed to reproduce identically on both Copperline and Amiberry, at matching in-instruction PCs.

## Fix

Declare the raw byte buffers as `uint8_t *`, exactly as the `exec/types.h` `APTR` warning advises ("`C` pointer math will not operate on APTR -- use `BYTE *` instead"). The existing `src = tsrc + dma_len` expression then means a correct byte offset with no other change.

The equivalent buffers in `test_dma_copy` are retyped the same way for consistency. They were already correct (they compute the offset through an explicit `(uint32_t)` cast), but the `APTR *` type was equally misleading; this also lets the offset line drop its cast.

Fixes #55