### PR TITLE
Fix three unbalanced interrupt/task-nesting bugs

### DIFF
--- a/port.c
+++ b/port.c
@@ -51,9 +51,6 @@
 //
 short bug=TRUE;
 
-/* Interrupt Level, >0 means interrupts are disabled */
-static int bsd_ilevel = 0;
-
 void
 panic(const char *fmt, ...)
 {
@@ -132,7 +129,7 @@ delay(int usecs)
     struct timerequest *tr;
     struct timeval tv;
 
-    if(bsd_ilevel > 0) {
+    if (SysBase->IDNestCnt >= 0) {
         printf("delay(%d): Interrupts disabled, using delay loop.\n", usecs);
         for (unsigned long i = 0; i < ((unsigned long)usecs << 3); i++)
             asm("nop");
@@ -153,23 +150,6 @@ delay(int usecs)
     tv.tv_micro = usecs % 1000000;
     wait_for_timer(tr, &tv);
     delete_timer(tr);
-}
-
-/* Block (nesting) interrupts */
-int
-bsd_splbio(void)
-{
-    Disable();
-    return (bsd_ilevel++);
-}
-
-/* Enable (nesting) interrupts */
-void
-bsd_splx(int ilevel)
-{
-    bsd_ilevel = ilevel;
-    if (bsd_ilevel == 0)
-        Enable();
 }
 
 const char *

--- a/port.h
+++ b/port.h
@@ -60,8 +60,21 @@ int irq_and_timer_handler(void);
 void *device_private(device_t dev);
 const char *device_xname(void *dev);
 
-int bsd_splbio(void);
-void bsd_splx(int ilevel);
+/* Block interrupts. The level is vestigial, only kept for the BSD callers. */
+static inline int
+bsd_splbio(void)
+{
+    Disable();
+    return (1);
+}
+
+/* Unblock interrupts. Disable()/Enable() already nest, so this is one-to-one. */
+static inline void
+bsd_splx(int ilevel)
+{
+    __USE(ilevel);
+    Enable();
+}
 
 #define hz TICKS_PER_SECOND
 #define mstohz(m) ((m) * TICKS_PER_SECOND / 1000)

--- a/siop.c
+++ b/siop.c
@@ -370,7 +370,7 @@ siop_poll(struct siop_softc *sc, struct siop_acb *acb)
                 --to;
                 if (to <= 0) {
 #ifdef PORT_AMIGA
-                    bsd_splbio();
+                    bsd_splx(s);
 #endif
                     siopreset(sc);
                     return;

--- a/siop2.c
+++ b/siop2.c
@@ -543,6 +543,7 @@ siopng_poll(struct siop_softc *sc, struct siop_acb *acb)
 				i = 50000;
 				--to;
 				if (to <= 0) {
+                                        bsd_splx(s);
 					siopngreset(sc);
 					return;
 				}


### PR DESCRIPTION
Fixes #57.

Three unbalanced interrupt/task-nesting bugs.

**port:** `bsd_splbio()` always took a `Disable()`, but `bsd_splx()` only
issued the matching `Enable()` when unwinding to level 0, so every *nested*
pair leaked one `Disable()`. `siop_poll()` nests by holding the spl across
`siop_scsidone()`. `IDNestCnt` is a signed byte, so the leak wrapped it
negative, which also defeats AROS's idle-loop disable-break (`IDNestCnt >= 0`)
-- the machine ends in `STOP` with INTENA masked and no way back in.

Since exec's `Disable()`/`Enable()` already nest, the private level was
redundant: it is dropped, both wrappers are inlined into `port.h`, and
`delay()` asks exec directly.

**siop:** the timeout exit paths in `siop_poll()` and `siopng_poll()` never
released the spl -- `siop_poll()` took a *second* `bsd_splbio()` and returned
with two `Disable()`s outstanding.

**3rdparty:** bump `mounter` for the nested `Forbid()` fix in
`find_filesystem()`.

Measured on an A4000/040 under Copperline booting AROS m68k from a SCSI
CD-ROM: `a4091.device`'s nest count goes from 214 (reading as -42 in the
signed byte) to 0, matching every other task, and the machine no longer
freezes.

Note this does **not** fix AROS CD-ROM booting. The hard freeze is gone, but
the mount still does not complete, so there is at least one more bug.

`siopng_poll()` is untested: `TARGET=NCR53C710` selects `siop.c`, so it is not
compiled for the A4091. That change is correct by symmetry.
